### PR TITLE
Update publications and news (May 2026)

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -68,6 +68,17 @@
   slides={Blastnet-slides.pdf}
 }
 
+@article{2026vexact,
+  abbr={arxiv},
+  selected={true},
+  title={Diagnosing Training Inference Mismatch in LLM Reinforcement Learning},
+  author={Zhong, Tianle and Ling, Neiwen and Pi, Yifan and Wei, Zijun and Yu, Tianshu and Fox, Geoffrey and Wu, Peng and Yu, Xiao},
+  abstract={Modern LLM RL systems separate rollout generation from policy optimization. These two stages are expected to produce token probabilities that match exactly. However, implementation differences can make them assign different values to the same sequence under the same model weights, inducing Training-Inference Mismatch (TIM). TIM is difficult to inspect because it is entangled with off-policy drift and common stabilization mechanisms. In this work, we isolate TIM in a zero-mismatch diagnostic setting (VeXact), and show that small token-level numerical disagreements can independently cause training collapse. We further show that TIM changes the effective optimization problem, and identify a set of remedies that could mitigate TIM. Our results suggest that TIM is not benign numerical noise, but a systems-level perturbation that should be treated as a first-order factor in analyzing LLM RL stability.},
+  year={2026},
+  journal={arXiv preprint arXiv:2605.14220},
+  html={https://arxiv.org/abs/2605.14220},
+}
+
 @article{2024timelyllm,
   abbr={MobiSys'26},
   selected={true},

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -88,6 +88,7 @@
   TimelyLLM introduces novel mechanisms of segmented generation and scheduling that optimally leverage redundancy between robot plan generation and execution phases.
   We report an implementation of TimelyLLM on a widely-used LLM serving framework and evaluate it on a range of robotic applications. Our evaluation shows that TimelyLLM improves the time utility up to 1.97x, and reduces the overall waiting time by 84%.},
   year={2026},
+  featured={Featured Paper},
   pdf={timelyllm.pdf},
   journal={The 24th ACM International Conference on Mobile Systems, Applications, and Services (ACM MobiSys 2026)},
   html={https://arxiv.org/abs/2412.18695},

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -72,7 +72,7 @@
   abbr={arxiv},
   selected={true},
   title={Diagnosing Training Inference Mismatch in LLM Reinforcement Learning},
-  author={Zhong, Tianle and Ling, Neiwen and Pi, Yifan and Wei, Zijun and Yu, Tianshu and Fox, Geoffrey and Wu, Peng and Yu, Xiao},
+  author={Zhong(co-primary), Tianle and Ling(co-primary), Neiwen and Pi, Yifan and Wei, Zijun and Yu, Tianshu and Fox, Geoffrey and Wu, Peng and Yu, Xiao},
   abstract={Modern LLM RL systems separate rollout generation from policy optimization. These two stages are expected to produce token probabilities that match exactly. However, implementation differences can make them assign different values to the same sequence under the same model weights, inducing Training-Inference Mismatch (TIM). TIM is difficult to inspect because it is entangled with off-policy drift and common stabilization mechanisms. In this work, we isolate TIM in a zero-mismatch diagnostic setting (VeXact), and show that small token-level numerical disagreements can independently cause training collapse. We further show that TIM changes the effective optimization problem, and identify a set of remedies that could mitigate TIM. Our results suggest that TIM is not benign numerical noise, but a systems-level perturbation that should be treated as a first-order factor in analyzing LLM RL stability.},
   year={2026},
   journal={arXiv preprint arXiv:2605.14220},

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -95,7 +95,6 @@
 
 @article{ling2021rt,
   abbr={SenSys'21},
-  selected={true},
   title={RT-mDL: Supporting Real-Time Mixed Deep Learning Tasks on Edge Platforms},
   author={Ling, Neiwen and Wang, Kai and He, Yuze and Xing, Guoliang and Xie, Daqi},
   abstract={Recent years have witnessed an emerging class of real-time applications, e.g., autonomous driving, in which resource-constrained edge platforms need to execute a set of real-time mixed Deep Learning (DL) tasks concurrently. Such an application paradigm poses major challenges due to the huge compute workload of deep neural network models, diverse performance requirements of different tasks, and the lack of real-time support from existing DL frameworks. In this paper, we present RT-mDL, a novel framework to support mixed real-time DL tasks on edge platform with heterogeneous CPU and GPU resource. 
@@ -133,7 +132,6 @@
 
 @article{ling2025tmc,
   abbr={TMC'25},
-  selected={true},
   title={Time-sensitive Multi-DNN Inference on CPU-GPU Edge Platforms},
   author={Ling, Neiwen and Lu, Wenrui and Huang, Xuan and Zhao, Zhihe and Guan, Nan and Yan, Zhenyu and Xing, Guoliang},
   journal={IEEE Transactions on Mobile Computing (IEEE TMC 2025)},
@@ -180,7 +178,6 @@
 
 @article{jiang2023coedge,
   abbr={IPSN'23},
-  selected={true},
   title={CoEdge: A Cooperative Edge System for Distributed Real-Time Deep Learning Tasks},
   author={Jiang(co-primary), Zhehao and Ling(co-primary), Neiwen and Huang, Xuan and Shi, Shuyao and Wu, Chenhao and Zhao, Xiaoguang and Yan, Zhenyu and Xing, Guoliang},
   abstract={Recent years have witnessed the emergence of a new class of cooperative edge systems in which a large number of edge nodes can collaborate through local peer-to-peer connectivity. In this paper, we propose CoEdge, a novel cooperative edge system that can support concurrent data/compute-intensive deep learning (DL) models for distributed real-time applications such as city-scale traffic monitoring and autonomous driving. First, CoEdge includes a hierarchical DL task scheduling framework that dispatches DL tasks to edge
@@ -206,7 +203,6 @@
 
 @article{zhao2022iot,
   abbr={SenSys'22Poster},
-  selected={true},
   title={Aaron: Compile-time Kernel Adaptation for Multi-DNN Inference Acceleration on Edge GPU},
   author={Zhao, Zhihe and Ling, Neiwen and Guan, Nan and Xing, Guoliang},
   journal={The 20th ACM Conference on Embedded Networked Sensor Systems},
@@ -236,7 +232,6 @@
 
 @article{zhao2023miriam,
   abbr={SenSys'23},
-  selected={true},
   title={Miriam: Exploiting Elastic Kernels for Real-time Multi-DNN Inference on Edge GPU},
   author={Zhao, Zhihe and Ling, Neiwen and Guan, Nan and Xing, Guoliang},
   journal = {The 21st ACM Conference on Embedded Networked Sensor Systems (ACM SenSys 2023)},
@@ -251,7 +246,6 @@
 
 @article{yang2023edgefm,
   abbr={SenSys'23},
-  selected={true},
   title={EdgeFM: Leveraging Foundation Model for Open-set Learning on the Edge},
   author={Yang, Bufang and He, Lixing and Ling, Neiwen and Yan, Zhenyu and Xing, Guoliang and Shuai, Xian and Ren Xiaozhe and Xin Jiang},
   journal = {The 21st ACM Conference on Embedded Networked Sensor Systems (ACM SenSys 2023)},

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -78,7 +78,7 @@
   We report an implementation of TimelyLLM on a widely-used LLM serving framework and evaluate it on a range of robotic applications. Our evaluation shows that TimelyLLM improves the time utility up to 1.97x, and reduces the overall waiting time by 84%.},
   year={2026},
   pdf={timelyllm.pdf},
-  journal={Conditionally accepted by The 23rd ACM International Conference on Mobile Systems, Applications, and Services (ACM MobiSys 2026)},
+  journal={The 24th ACM International Conference on Mobile Systems, Applications, and Services (ACM MobiSys 2026)},
   html={https://arxiv.org/abs/2412.18695},
 }
 

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -128,6 +128,9 @@
              {%- if entry.award -%}
         <br><span style="color: #B71C1C"><b>{{entry.award}}</b></span>
         {%- endif -%}
+             {%- if entry.featured -%}
+        <br><span style="color: #F57C00">{{entry.featured}}</span>
+        {%- endif -%}
         </div>
         {%- endif %}
         

--- a/_news/announcement_24.md
+++ b/_news/announcement_24.md
@@ -1,0 +1,7 @@
+---
+layout: post
+date: 2026-05-14 08:00:00-0400
+inline: true
+---
+
+Our latest paper on training-inference mismatch in LLM RL is available on <a href="https://arxiv.org/abs/2605.14220" target="_blank" rel="noopener noreferrer">arXiv</a>, with VeXact open-sourced at <a href="https://github.com/verl-project/vexact" target="_blank" rel="noopener noreferrer">verl-project/vexact</a>.

--- a/_news/announcement_25.md
+++ b/_news/announcement_25.md
@@ -1,0 +1,7 @@
+---
+layout: post
+date: 2026-05-18 08:00:00-0400
+inline: true
+---
+
+Will attend <a href="https://mlsys.org/Conferences/2026" target="_blank" rel="noopener noreferrer">MLSys 2026</a>.

--- a/_news/announcement_26.md
+++ b/_news/announcement_26.md
@@ -1,0 +1,7 @@
+---
+layout: post
+date: 2026-05-15 08:00:00-0400
+inline: true
+---
+
+TimelyLLM was selected as a Featured Paper at <a href="https://www.sigmobile.org/mobisys/2026/" target="_blank" rel="noopener noreferrer">ACM MobiSys 2026</a>.


### PR DESCRIPTION
## Summary
- **TimelyLLM**: formally accepted (removed "Conditionally accepted by" prefix); corrected MobiSys 2026 edition from 23rd to 24th
- **New paper**: added "Diagnosing Training Inference Mismatch in LLM Reinforcement Learning" (arXiv:2605.14220)
- **Selected Publications**: 
- **News**: added arXiv release / VeXact open-source announcement

## Test plan
- [ ] Verify publications page renders updated entries and selected list correctly
- [ ] Verify new news items appear on the homepage